### PR TITLE
Update seminars list and navigation

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -2,7 +2,7 @@
 layout: default
 permalink: /blog/
 title: blog
-nav: true
+nav: false
 nav_order: 1
 pagination:
   enabled: true

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -4,7 +4,7 @@ title: projects
 permalink: /projects/
 description: A growing collection of your cool projects.
 nav: true
-nav_order: 3
+nav_order: 4
 display_categories: [work, fun]
 horizontal: false
 ---

--- a/_pages/seminars.md
+++ b/_pages/seminars.md
@@ -3,47 +3,208 @@ layout: page
 title: seminars
 permalink: /seminars/
 nav: true
-nav_order: 4
+nav_order: 3
 ---
+
+## 2025
+
+- **11 June 2025** | **Large-scale deep-learning for weather and climate prediction** — **Laure Raynauld** (CNRM/MétéoFrance)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> A new paradigm for weather and climate prediction has emerged recently: data-driven prediction models have become competitive with standard physics-based models on many aspects, thanks to an accurate encoding of the data distribution. Most models have been developed for task-specific purposes and are trained on a single type of data (such as the ERA5 reanalysis). The next challenge to expand the capabilities of data-driven modeling is to fully exploit the vast range of atmospheric observations, characterized by spatio-temporal variations and heterogeneous outputs (point or spatial time series, vertical profiles, vertically integrated data, … ). This naturally leads to the development of foundation models that learn a task-agnostic representation of the atmosphere. An overview of the most advanced models will be presented, as well as early results for integrating heterogeneous data sources.
+  <br><br>
+  <strong>Bio:</strong> A graduate of the National School of Meteorology and holder of a PhD from the University of Toulouse 3, Laure Raynaud is a researcher in numerical weather prediction at the National Center for Meteorological Research (CNRM/MétéoFrance). Her research focuses mainly on data assimilation and probabilistic forecasting. She regularly collaborates with several applied fields (agriculture, energy, transportation). Her recent work explores artificial intelligence methods and their use in the computation and operational application of weather forecasts. She holds a chair at the Toulouse Artificial Intelligence Institute (ANITI).
+  </blockquote>
+  </details>
 
 ## 2023
 
-- **High-resolution canopy height and wood volume maps in France based on satellite remote sensing with a Deep Learning approach**
-- **Machine learning for climate change and environmental sustainability**
+- **27 March 2023** | **High-resolution canopy height and wood volume maps in France based on satellite remote sensing with a Deep Learning approach** — **Martin Schwartz** (Kayrros)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> The project "High-resolution canopy height and wood volume maps in France based on satellite remote sensing with a Deep Learning approach" involves developing a deep learning U-Net model. This model utilizes multi-band images from Sentinel-1 and Sentinel-2 satellites, incorporating composite time averages as input. The primary goal is to predict tree height based on GEDI waveforms. Subsequently, forest inventory plots are used to transform this height map into a 10-meter resolution wood volume map, enabling wood volume estimations across various French regions. This approach facilitates high-resolution biomass monitoring, offering vital data for informed forest management policies in France.
+  <br><br>
+  <strong>Bio:</strong> Martin Schwartz is a researcher at Kayrros, a French company leveraging expertise in AI and satellite imagery to provide insights for energy and commodity markets, with a strong focus on sustainability and environmental issues.
+  </blockquote>
+  </details>
+
+- **6 February 2023** | **Machine learning for climate change and environmental sustainability** — **Claire Monteleoni** (INRIA Paris / University of Colorado Boulder)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> Machine learning can help improve predictions, assess impacts and vulnerabilities, and inform strategies for mitigation and sustainable adaptation. The seminar covered climate informatics research, focusing on challenges in learning from spatiotemporal data and exploring semi-supervised and unsupervised deep learning approaches for studying rare and extreme events, as well as precipitation and temperature downscaling.
+  <br><br>
+  <strong>Bio:</strong> Claire Monteleoni is a Choose France Chair in AI and Directrice de Recherche at INRIA Paris, as well as an Associate Professor at the University of Colorado Boulder. Her work has been instrumental in establishing the interdisciplinary domain of Climate Informatics.
+  </blockquote>
+  </details>
 
 ## 2022
 
-- **Variational Data Assimilation with Deep Prior**
-- **Eddy Detecting Neural Networks: harnessing visible satellite imagery and altimetry for operation oceanography**
-- **Towards the combination of physical and data-driven forecasts for Earth system prediction**
+- **5 October 2022** | **Variational Data Assimilation with Deep Prior** — **Arthur Filoche** (LIP6)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> The seminar focused on the hybridization of deep learning and data assimilation algorithms to address challenges in fields like numerical weather prediction and geophysical motion estimation. Arthur Filoche's work proposes replacing the conventional Gaussian prior with a deep convolutional prior. This approach circumvents the need for explicit background error covariances. The methodology involves reshaping the optimization so that the initial condition to be estimated is generated by a deep architecture. This neural network is optimized on a single observational window in an unsupervised manner, with the bias induced by the architecture providing regularization through convolution operators that impose locality.
+  <br><br>
+  <strong>Bio:</strong> Arthur Filoche is a researcher at LIP6, Sorbonne Université.
+  </blockquote>
+  </details>
+
+- **11 May 2022** | **Eddy Detecting Neural Networks: harnessing visible satellite imagery and altimetry for operation oceanography** — **Evangelos Moschos**
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> Machine learning in oceanography is vital for analyzing extensive and complex datasets from satellite sensors, which improves data accuracy, enhances resolution, and enables more precise predictions of oceanic phenomena. The work presented utilizes neural networks for eddy detection, harnessing visible satellite imagery and altimetry for operational oceanography. This capability is critical for tasks such as monitoring the decline of ocean oxygen and understanding marine ecosystems.
+  <br><br>
+  <strong>Bio:</strong> Evangelos Moschos is a researcher working on AI applications in oceanography.
+  </blockquote>
+  </details>
+
+- **26 January 2022** | **Towards the combination of physical and data-driven forecasts for Earth system prediction** — **Eviatar Bach** (ENS Paris / Caltech)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> The seminar explores hybrid methods that integrate machine learning (ML) with traditional physical models to improve Earth system predictions. Given the high dimensionality of Earth systems, the research emphasizes the critical need for hybrid approaches that combine data-driven models, physical models, and observations. Two key hybrid methods are introduced: Ensemble Oscillation Correction (EnOC), which aims to correct oscillatory modes in ensemble forecasts, and Multi-model Data Assimilation (MM-DA), a generalized approach for combining multiple models and observations by estimating model error.
+  <br><br>
+  <strong>Bio:</strong> Eviatar Bach is affiliated with ENS Paris and Caltech's Division of Geological and Planetary Sciences.
+  </blockquote>
+  </details>
 
 ## 2021
 
-- **19 October 2021** | [New ways for dynamical prediction of extreme heat waves: rare event simulations and machine learning with deep neural networks.](https://ai4climate.lip6.fr/2021/10/11/new-ways-for-dynamical-prediction-of-extreme-heat-waves-rare-event-simulations-and-machine-learning-with-deep-neural-networks-freddy-bouchet-ens-lyon/) — **Freddy Bouchet**
-- **23 June 2021** | [Climate Modeling in the Age of Machine Learning](https://ai4climate.lip6.fr/2021/06/15/climate-modeling-in-the-age-of-machine-learning-laure-zanna-nyu/) — **Laure Zanna** (remotely)
-- **6 May 2021** | [Filling gaps in ocean satellite data](https://ai4climate.lip6.fr/2021/04/21/filling-gaps-in-ocean-satellite-data-aida-alvera-azcarate-alexander-barth/) ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2021/06/DINEOF_DINCAE_ai4climate-1.pdf)) — **Aida Alvera-Azcárate** (remotely)
-- **26 March 2021** | [Narrowing uncertainties of climate projections using data science tools](https://ai4climate.lip6.fr/2021/03/15/narrowing-uncertainties-of-climate-projections-using-data-science-tools-pierre-tandeo/) ([slides](https://ai4climate.lip6.fr/presentation_ai4climate_2021_03_26/)) — **Pierre Tandeo** (remotely)
-- **10 February 2021** | [Machine learning and natural hazards](https://ai4climate.lip6.fr/2021/01/15/machine-learning-and-natural-hazards-sophie-giffard-roisin/) ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2021/02/presentation_SAMA_SCAI_online.pdf)) — **Sophie Giffard-Roisin** (remotely)
+- **3 December 2021** | **What is the cost? Calculating the environmental impact of scientific calculus** — **Anne-Laure Ligozat** (ENSIIE / LISN)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> In this presentation, we will analyze the environmental impacts of numerical computations, and especially scientific calculus. We will consider the impacts at the level of the code/program, and at the level of the laboratory. We will also present existing tools for monitoring the carbon footprint and their limitations.
+  <br><br>
+  <strong>Bio:</strong> Anne-Laure Ligozat is an assistant professor in informatics at ENSIIE and at the LISN lab of Saclay. Her research interests are the environmental impact of informatics.
+  </blockquote>
+  </details>
+
+- **19 October 2021** | **New ways for dynamical prediction of extreme heat waves: rare event simulations and machine learning with deep neural networks.** — **Freddy Bouchet**
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> In the climate system, extreme events or transitions between climate attractors are of primarily importance for understanding the impact of climate change. Recent extreme heat waves with huge impacts are striking examples. However, it is very hard to study those events with conventional approaches, because of the lack of statistics, because they are too rare for historical data and because realistic models are too complex to be run long enough. We cope with this lack of data issue using rare event simulations. Using some of the best climate models, we oversample extremely rare events and obtain several hundreds more events than with usual climate runs, at a fixed numerical cost. Coupled with deep neural networks this approach improves drastically the prediction of extreme heat waves. This shed new light on the fluid mechanics processes which lead to extreme heat waves. We will describe quasi-stationary patterns of turbulent Rossby waves that lead to global teleconnection patterns in connection with heat waves and analyze their dynamics. We stress the relevance of these patterns for recently observed extreme heat waves and the prediction potential of our approach.
+  </blockquote>
+  </details>
+
+- **23 June 2021** | **Climate Modeling in the Age of Machine Learning** — **Laure Zanna** (remotely)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> Numerical simulations used for weather and climate predictions solve approximations of the governing laws of fluid motions on a grid. Ultimately, uncertainties in climate predictions originate from the poor or lacking representation of processes, such as ocean turbulence and clouds that are not resolved on the grid of global climate models. The representation of these unresolved processes has been a bottleneck in improving climate simulations and projections. The explosion of climate data and the power of machine learning algorithms are suddenly offering new opportunities: can we deepen our understanding of these unresolved processes and simultaneously improve their representation in climate models to reduce climate projections uncertainty? In this talk, I will discuss the current state of climate modeling and its future, focusing on the advantages and challenges of using machine learning for climate projections. I will present some of our recent work in which we leverage tools from machine learning and deep learning to learn representations of unresolved ocean processes and improve climate simulations. Our work suggests that machine learning could open the door to discovering new physics from data and enhance climate predictions.
+  <br><br>
+  <strong>Bio:</strong> Laure Zanna is a Professor in Mathematics & Atmosphere/Ocean Science at the Courant Institute, New York University. Her research focuses on the role of ocean dynamics in climate change. Prior to NYU, she was a faculty member at the University of Oxford until 2019 and obtained her PhD in 2009 in Climate Dynamics from Harvard University. She was the recipient of the 2020 Nicholas P. Fofonoff Award from the American Meteorological Society “For exceptional creativity in the development and application of new concepts in ocean and climate dynamics”. She is the lead principal investigator of M²LInES, an international effort supported by Schmidt Futures to improve climate models with scientific machine learning.
+  </blockquote>
+  </details>
+
+- **6 May 2021** | **Filling gaps in ocean satellite data** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2021/06/DINEOF_DINCAE_ai4climate-1.pdf)) — **Aida Alvera-Azcárate** (remotely)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> Satellite data offer an unequalled amount of information of the Earth’s surface, including the ocean. However, data measured using visible and infrared wavebands are affected by the presence of clouds and have therefore a large amount of missing data (on average, clouds cover about 75% of the Earth). The spatial and temporal scales of variability in the ocean require techniques able to handle undersampling of the dominant scales of variability. The GHER (GeoHydrodynamics and Environment Research) of the University of Liege in Belgium has been working over the last two decades on interpolation techniques for satellite and in situ ocean data. In this talk we will focus on techniques developed for satellite data. We’ll start with DINEOF – Data Interpolating Empirical Orthogonal Functions- which is a data-driven technique using EOFs to infer missing information in satellite datasets. We will follow with a more recent development, DINCAE – Data Interpolating Convolutional AutoEncoder. Training a neural network with incomplete data is problematic, and this is overcome in DINCAE by using the satellite data and its expected error variance as input. The autoencoder provides the reconstructed field along with its expected error variance as output. We will provide examples of reconstructed satellite data for several variables, like sea surface temperature, chlorophyll concentration, and some recent developments with DINCAE to grid altimetry data to complete fields.
+  <br><br>
+  <strong>Bio:</strong> Aida Alvera-Azcárate is a researcher at the GHER (GeoHydrodynamics and Environment Research) of the University of Liege in Belgium. She did a PhD in Science at the University of Liege and made a post-doc at the University of South Florida (US) before joining the GHER in 2007 where she studies the ocean using satellite and in situ data and works in the development of interpolation techniques to reconstruct satellite data. Alexander Barth is a researcher working at the University of Liege (Belgium) in the GHER group (GeoHydrodynamics and Environment Research). He did a PhD on nested numerical ocean models and data assimilation. Currently he is working on variational analysis schemes for climatologies and neural networks to reconstruct missing data.
+  </blockquote>
+  </details>
+
+- **26 March 2021** | **Narrowing uncertainties of climate projections using data science tools** ([slides](https://ai4climate.lip6.fr/presentation_ai4climate_2021_03_26/)) — **Pierre Tandeo** (remotely)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> Climate indices show large variability in CMIP climate predictions. In this presentation, we propose to weight multi-model climate simulations to reduce the uncertainty in climate predictions, and better estimate the future evolution of climate indices. The proposed methodology is based on advanced data science tools (i.e, data assimilation, analog forecasting, model evidence metrics), to accurately compute distances between current observations and simulated climate indices. This low-cost procedure is tested on a simplified climate model. The results show that the methods can be applied locally and is able to identify relevant parameterizations.
+  <br><br>
+  <strong>Bio:</strong> Pierre Tandeo an associate professor at IMT Atlantique (Brest, France) and an associate researcher at the Data Assimilation Research Team, RIKEN Center for Computational Science (Kobe, Japan). More information: <a href="https://tandeo.wordpress.com/">https://tandeo.wordpress.com/</a>.
+  </blockquote>
+  </details>
+
+- **10 February 2021** | **Machine learning and natural hazards** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2021/02/presentation_SAMA_SCAI_online.pdf)) — **Sophie Giffard-Roisin** (remotely)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> The goal of this talk is to show how we can use the strength of artificial intelligence to help making diagnosis and finding concrete and local solutions to natural hazards. Tropical cyclones, avalanches, earthquakes or landslides affects often vulnerable areas and populations, where the understanding of the phenomena and better risk assessment and predictions can make a substantial impact. The data available to monitor these natural phenomena has considerably increased in the recent years. For example, SAR (synthetic aperture radar) imaging data, provided by the Sentinel 1 satellites, is now freely available up to every 6 days in a majority of regions, even remote areas. Yet, artificial intelligence (AI) and machine learning (ML) have only scarcely been used in these domains. But these techniques have already showed their impact in many scientific fields having similar data structures (large volume of data, presence of noise, complex physical phenomena) such as medical imaging (detection/segmentation of pathologies), crop yield (prediction), security (recognition). We will see in this talk, with concrete examples, how to design machine learning models for specific tasks with real imaging or temporal data inputs. Concretely, starting mainly from convolutional neural networks, what are the key aspects to consider and what are pitfalls to avoid?
+  <br><br>
+  <strong>Bio:</strong> Sophie Giffard-Roisin is a researcher hired by IRD (French National Institute for Sustainable Development) and based at ISTerre, Grenoble (UGA, France). Her work focuses on machine learning applications for natural hazards, especially using remote sensing and time series data. She did her PhD at Inria, Nice (France) under the supervision of Nicholas Ayache on machine learning and modelling for medical image analysis. Then she did a post-doc in CU Boulder, Colorado (USA) in Claire Monteleoni’s team where she worked on climate and meteorological applications of machine learning. She moved to ISTerre, the Earth Science Laboratory of Grenoble Université (UGA, France), for a permanent position in 2019 where she now focuses on machine learning for natural hazards in geosciences.
+  </blockquote>
+  </details>
 
 ## 2020
 
-- **4 December 2020** | [Inferring causation from time series with perspectives in Earth system sciences](https://ai4climate.lip6.fr/2020/01/23/inferring-causation-from-time-series-with-perspectives-in-earth-system-sciences-jakob-runge-25-03-2020/) ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2020/12/Runge_causal_discovery_and_effects.pdf)) — **Jakob Runge** (remotely)
-- **14 October 2020** | [Power-efficient deep learning algorithms](https://ai4climate.lip6.fr/2020/09/22/power-efficient-deep-learning-algorithms-sebastien-loustau/) ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2020/10/Regret_Bounds-1-43-1.pdf)) — **Sébastien Loustau**
-- **24 January 2020** | [A direct approach to detection and attribution of climate change](https://ai4climate.lip6.fr/2020/01/10/a-direct-approach-to-detection-and-attribution-of-climate-change-eniko-szekely-24-01-2020/) ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2020/02/Szekely_AI4Climate.pdf)) — **Eniko Szekely**
+- **4 December 2020** | **Inferring causation from time series with perspectives in Earth system sciences** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2020/12/Runge_causal_discovery_and_effects.pdf)) — **Jakob Runge** (remotely)
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> The heart of the scientific enterprise is a rational effort to understand the causes behind the phenomena we observe. In disciplines dealing with complex dynamical systems, such as the Earth system, replicated real experiments are rarely feasible. However, a rapidly increasing amount of observational and simulated data opens up the use of novel data-driven causal inference methods beyond the commonly adopted correlation techniques. In this talk, I will present a recent Perspective Paper in Nature Communications giving an overview of causal inference methods and identify key tasks and major challenges where causal methods have the potential to advance the state-of-the-art in Earth system sciences. Several methods will be illustrated by `success’ examples where causal inference methods have already led to novel insights and I will close with an outlook of this relatively new and exciting field. I will also present the causal inference benchmark platform <a href="www.causeme.net">www.causeme.net</a> that aims to assess the performance of causal inference methods and to help practitioners choose the right method for a particular problem.
+  <br><br>
+  <strong>Bio:</strong> Jakob Runge heads the Climate Informatics working group at the German Aerospace Center’s Institute of Data Science since 2017. The group combines innovative data science methods from different fields (graphical models, causal inference, nonlinear dynamics, deep learning) and closely works with experts in the climate sciences. Jakob studied physics at Humboldt University Berlin and obtained his PhD at the Potsdam Institute for Climate Impact Research in 2014. For his studies, he was funded by the German National Foundation (Studienstiftung) and his thesis was awarded the Carl-Ramsauer prize by the Berlin Physical Society. In 2014 he won a $200.000 Fellowship Award in Studying Complex Systems by the James S. McDonnell Foundation and joined the Grantham Institute, Imperial College, from 2016 to 2017. On <a href="https://github.com/jakobrunge/tigramite.git">https://github.com/jakobrunge/tigramite.git</a> he provides Tigramite, a time series analysis python module for causal inference. For more details, see: <a href="www.climateinformaticslab.com">www.climateinformaticslab.com</a>
+  </blockquote>
+  </details>
+
+- **14 October 2020** | **Power-efficient deep learning algorithms** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2020/10/Regret_Bounds-1-43-1.pdf)) — **Sébastien Loustau**
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> In this talk, I will present both theoretical and practical aspect of how designing power-efficient deep learning algorithms. After a non-exhaustive survey of different contributions about the machine learning perspective (training low bit-width networks), the hardware counterpart (CNNs accelerators) and the relationship with Auto-ML and the NAS procedure, I will present a theoretically based approach to add the power efficiency constraint into the optimization procedure of training deep nets. This work in progress bridges optimal transport and information theory with online learning.
+  <br><br>
+  <strong>Bio:</strong> Sébastien is a researcher in mathematical statistics and Machine Learning. He has studied the theoretical aspect of both statistical and online learning. His research interests include online learning, unsupervised learning, adaptive algorithms and minimax theory. He also founded LumenAI 5 years ago.
+  </blockquote>
+  </details>
+
+- **24 January 2020** | **A direct approach to detection and attribution of climate change** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2020/02/Szekely_AI4Climate.pdf)) — **Eniko Szekely**
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> In this talk I will present a novel statistical learning approach for detection and attribution (D&A) of climate change. Traditional optimal D&A studies try to directly model the observations from model simulations, but practically this is challenging due to high-dimensionality. Here, we propose a supervised approach where we predict a given metric or external forcing directly from the high-dimensional spatial pattern of climate variables, and use the predicted metric as a test statistic for D&A. The first part of the talk will focus on daily detection and show that we can now detect climate change from global weather for any single day since spring 2012. The second part of the talk will focus on attribution of climate change. For attribution, we want the prediction of the external forcing, e.g., anthropogenic forcing, to work well even under changes in the distribution of other external forcings, e.g., solar or volcanic forcings. Therefore we formulate the optimization problem from a distributional robustness perspective, and use anchor regression to ensure good predictions even under such distributional changes.
+  <br><br>
+  <strong>Bio:</strong> Eniko is a senior data scientist at the Swiss Data Science Center, EPFL & ETH Zurich, working on machine learning for climate science. Previously, she was a postdoctoral researcher at the Courant Institute of Mathematical Sciences, New York University, and she obtained her PhD in Computer Science from the University of Geneva, Switzerland. Broadly she is interested in machine learning for high-dimensional data and nonlinear phenomena arising from dynamical systems. More recently she has been working on using machine learning and statistical learning approaches for climate science, and has been involved in the organization of the Climate Informatics workshop since 2015.
+  </blockquote>
+  </details>
 
 ## 2019
 
-- **4 December 2019** | [Deep Learning for Satellite Imagery: Semantic Segmentation, Non-Rigid Alignment, and Self-Denoising](https://ai4climate.lip6.fr/2019/11/14/deep-learning-for-satellite-imagery-semantic-segmentation-non-rigid-alignment-and-self-denoising-guillaume-charpiat-4-decembre-2019/) ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2019/12/expo_LIP6_Charpiat.pdf)) — **Guillaume Charpiat**
-- **20 September 2019** | [Prévision d’ensemble par apprentissage séquentiel en météorologie, et méta-modélisation en pollution urbaine](https://ai4climate.lip6.fr/2019/09/10/prevision-densemble-par-apprentissage-sequentiel-en-meteorologie-et-meta-modelisation-en-pollution-urbaine-vivien-mallet-20-septembre-2019/) ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2019/09/presentation-Vivien-Mallet-20-09-2019.pdf)) — **Vivien Mallet**
-- **15 May 2019** | [Learning & Dynamical Systems: application to ocean dynamics](https://ai4climate.lip6.fr/2019/05/15/learning-dynamical-systems-application-to-ocean-dynamics%ef%bb%bf-ronan-fablet-15-may-2019-slides/) ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2019/05/pres_rfablet_SU_20190515.pdf)) — **Ronan Fablet**
-- **5 April 2019** | [Artificial Intelligence for Very High Resolution Earth Observation: Environment Monitoring](https://ai4climate.lip6.fr/2019/03/18/artificial-intelligence-for-very-high-resolution-earth-observation-environment-monitoring-mihai-datcu-05-apr-2019/) — **Mihai Datcu**
-- **20 February 2019** | Machine learning and the post-Dennard era of climate simulation (slides) — **V. Balaji**
-- **11 January 2019** | Deep Learning for Climate ([slides](https://ai4climate.lip6.fr/talk_ai_climate/)) — **Nicolas Thome**
+- **4 December 2019** | **Deep Learning for Satellite Imagery: Semantic Segmentation, Non-Rigid Alignment, and Self-Denoising** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2019/12/expo_LIP6_Charpiat.pdf)) — **Guillaume Charpiat**
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> Neural networks have been producing impressive results in computer vision these last years, in image classification or segmentation in particular. To be transferred to remote sensing, this tool needs adaptation to its specifics: large images, many small objects per image, keeping high-resolution output, unreliable ground truth (usually mis-registered). We will review the work done in our group for remote sensing semantic segmentation, explaining the evolution of our neural net architecture design to face these challenges, and finally training a network to register binary cadaster maps to RGB images while detecting new buildings if any, in a multi-scale approach. We will show in particular that it is possible to train on noisy datasets, and to make predictions at an accuracy much better than the variance of the original noise. To explain this phenomenon, we build theoretical tools to express input similarity from the neural network point of view, and use them to quantify data redundancy and associated expected denoising effects. If time permits, we might also present work on hurricane track forecast from reanalysis data (2-3D coverage of the Earth’s surface with temperature/pressure/etc. fields) using deep learning.
+  <br><br>
+  <strong>Bio:</strong> After a PhD thesis at ENS on shape statistics for image segmentation, and a year in Bernhard Schölkopf’s team at MPI Tübingen on kernel methods for medical imaging, Guillaume Charpiat joined INRIA Sophia-Antipolis to work on computer vision, and later INRIA Saclay to work on machine learning. Lately, he has been focusing on deep learning, with in particular remote sensing imagery as an application field. Affiliation: Guillaume Charpiat (Équipe TAU, INRIA Saclay / LRI – Université Paris-Sud)
+  </blockquote>
+  </details>
+
+- **20 September 2019** | **Prévision d’ensemble par apprentissage séquentiel en météorologie, et méta-modélisation en pollution urbaine** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2019/09/presentation-Vivien-Mallet-20-09-2019.pdf)) — **Vivien Mallet**
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> Le séminaire aura pour objectif d’illustrer certains apports de l’apprentissage dans des applications environnementales complexes. La première partie concernera la prévision d’ensemble. Un objectif est d’agréger un ensemble de prévisions en une prévision unique et meilleure que chaque prévision de l’ensemble. Une approche plus ambitieuse consiste à prévoir une distribution de probabilité afin de conserver une mesure de l’incertitude de prévision. Nous verrons qu’il est possible de prévoir une distribution plus performante que toute distribution empirique formée par une pondération constante des prévisions de l’ensemble. Les travaux seront illustrés par la prévision du rayonnement solaire et de la production photovoltaïque d’EDF. La seconde partie concernera la substitution d’un modèle environnemental, complexe et numériquement coûteux, par un méta-modèle extrêmement rapide et pourtant suffisamment fidèle au modèle complet. Nous verrons comment il est possible de remplacer un modèle non-linéaire opérant en grande dimension en (1) procédant à une réduction de dimension sur ses entrées et ses sorties, et (2) apprenant le comportement du modèle par un échantillonnage adapté. Il est aussi possible d’y mêler des données d’observation (issues de stations ponctuelles) pour améliorer les prévisions du méta-modèle. L’approche sera illustrée par la simulation de la pollution atmosphérique et de la pollution sonore en milieu urbain, à la résolution de la rue.
+  <br><br>
+  <strong>Bio:</strong> Vivien Mallet est chercheur au centre INRIA de Paris. Il travaille sur l’assimilation de données (couplage modélisation/observation) et la quantification des incertitudes pour des problèmes en environnement.
+  </blockquote>
+  </details>
+
+- **15 May 2019** | **Learning & Dynamical Systems: application to ocean dynamics** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2019/05/pres_rfablet_SU_20190515.pdf)) — **Ronan Fablet**
+
+- **5 April 2019** | **Artificial Intelligence for Very High Resolution Earth Observation: Environment Monitoring** — **Mihai Datcu**
+  <details>
+  <summary>Abstract & Bio</summary>
+  <blockquote>
+  <strong>Abstract:</strong> The Earth is facing unprecedented climatic, geomorphologic, environmental and anthropogenic changes, which require global scale observation and monitoring. Thus a multitude of new orbital and suborbital Earth Observation (EO) sensors and mission are in operation or will be soon launched. The interest is in a global understanding involving observation of large extended areas, and long periods of time, with a broad variety of EO sensors. The collected EO data volumes are thus increasing immensely with a rate of many Terabytes of data a day. With the current EO technologies these figure will be soon amplified, the horizons are beyond Zettabytes of data. The challenge is the exploration of these data and the timely delivery of focused information and knowledge in a simple understandable format. Therefore, search engines, and Data Mining are new fields of study that have arisen to seek solutions to automating the extraction of information from EO observations and other related sources that can lead to Knowledge Discovery and the creation of an actionable intelligence. Knowledge Discovery is among the most interesting research trends, however, the real challenge is to combine Artificial Intelligence with the power and potential of human intelligence, this being a primary objective in the field of Human Machine Communication (HMC). The goal is to go beyond the today methods of information retrieval and develop new concepts and methods to support end users of EO data to interactively analyze the information content, extract relevant parameters, associate various sources of information, learn and/or apply knowledge and to visualize the pertinent information without getting overwhelmed. In this context, the synergy of HMC and information retrieval becomes an interdisciplinary approach in automating EO data analysis.
+  <br><br>
+  <strong>Bio:</strong> Mihai Datcu received the M.S. and Ph.D. degrees in Electronics and Telecommunications from the University Politechnica Bucharest UPB, Romania, in 1978 and 1986. In 1999 he received the title Habilitation à diriger des recherches in Computer Science from University Louis Pasteur, Strasbourg, France. Currently he is Senior Scientist and Data Intelligence and Knowledge Discovery research group leader with the Remote Sensing Technology Institute (IMF) of the German Aerospace Center (DLR), Oberpfaffenhofen, and Professor with the Department of Applied Electronics and Information Engineering, Faculty of Electronics, Telecommunications and Information Technology, UPB. From 1992 to 2002 he had a longer Invited Professor assignment with the Swiss Federal Institute of Technology, ETH Zurich. From 2005 to 2013 he has been Professor holder of the DLR-CNES Chair at ParisTech, Paris Institute of Technology, Telecom Paris. His interests are in Data Science, Machine Learning and Artificial Intelligence, and Computational Imaging for space applications. He is involved in Big Data from Space European, ESA, NASA and national research programs and projects. He is a member of the ESA Big Data from Space Working Group. He received in 2006 the Best Paper Award, IEEE Geoscience and Remote Sensing Society Prize, in 2008 the National Order of Merit with the rank of Knight, for outstanding international research results, awarded by the President of Romania, and in 1987 the Romanian Academy Prize Traian Vuia for the development of SAADI image analysis system and activity in image processing. He is IEEE Fellow. He is holder of a 2017 Blaise Pascal Chair at CEDRIC, CNAM.
+  </blockquote>
+  </details>
+
+- **20 February 2019** | **Machine learning and the post-Dennard era of climate simulation** (slides) — **V. Balaji**
+- **11 January 2019** | **Deep Learning for Climate** ([slides](https://ai4climate.lip6.fr/talk_ai_climate/)) — **Nicolas Thome**
 
 ## 2018
 
-- **21 November 2018** | Modélisation d’incertitudes affectant les modèles numériques complexes ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/11/IA-climate.pdf)) — **Nicolas Bousquet**
-- **5 October 2018** | Machine learning in scientific workflows ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/10/kegl2.pdf)) — **Balázs Kégl**
-- **25 May 2018** | Deep‐Learning for Climate ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/10/2018-05-25-Deep-Learning-Climate-Gallinari-2.pdf)) — **Patrick Gallinari**
-- **9 April 2018** | Algorithms for Climate Informatics ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/11/samaSorbonne18.pdf)) — **Claire Monteleoni**
-- **1 February 2018** | Eddy detection with deep learning ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/11/Pres_SAMA_1Fevrier2018.pdf)) — **Alexandre Stegner**
+- **21 November 2018** | **Modélisation d’incertitudes affectant les modèles numériques complexes** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/11/IA-climate.pdf)) — **Nicolas Bousquet**
+- **5 October 2018** | **Machine learning in scientific workflows** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/10/kegl2.pdf)) — **Balázs Kégl**
+- **25 May 2018** | **Deep‐Learning for Climate** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/10/2018-05-25-Deep-Learning-Climate-Gallinari-2.pdf)) — **Patrick Gallinari**
+- **9 April 2018** | **Algorithms for Climate Informatics** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/11/samaSorbonne18.pdf)) — **Claire Monteleoni**
+- **1 February 2018** | **Eddy detection with deep learning** ([slides](https://ai4climate.lip6.fr/wp-content/uploads/2018/11/Pres_SAMA_1Fevrier2018.pdf)) — **Alexandre Stegner**


### PR DESCRIPTION
This PR updates the seminars page with missing 2022-2023 entries, adds a 2025 entry, removes old abstract links, hides the blog tab, and reorders the navigation.